### PR TITLE
Add support for scope configuration style matching README

### DIFF
--- a/src/Provider/Cognito.php
+++ b/src/Provider/Cognito.php
@@ -68,7 +68,11 @@ class Cognito extends AbstractProvider
         }
 
         if (!empty($options['scope'])) {
-            $this->scopes = explode($this->getScopeSeparator(), $options['scope']);
+            if (is_array($options['scope'])) {
+                $this->scopes = $options['scope'];
+            } else {
+                $this->scopes = explode($this->getScopeSeparator(), $options['scope']);
+            }
         }
     }
 

--- a/test/src/Provider/CognitoTest.php
+++ b/test/src/Provider/CognitoTest.php
@@ -102,6 +102,18 @@ class CognitoTest extends TestCase
         $this->assertEquals(['test-scope', 'test-scope-2'], $provider->getScopes());
     }
 
+    public function testSetScopeInConfigAsArray()
+    {
+        $provider = new \CakeDC\OAuth2\Client\Provider\Cognito([
+            'clientId' => 'mock_client_id',
+            'clientSecret' => 'mock_secret',
+            'redirectUri' => 'none',
+            'hostedDomain' => 'mock_hosted_domain',
+            'scope' => ['test-scope', 'test-scope-2']
+        ]);
+        $this->assertEquals(['test-scope', 'test-scope-2'], $provider->getScopes());
+    }
+
     public function testSetHostedDomainInConfig()
     {
         $host = uniqid();


### PR DESCRIPTION
Add support for scope configuration style matching README's style.

Kept the current support for string scope list to avoid BC issues.

In relation to issue: #5 

