### PR TITLE
Fix URL issues as per new requirements

### DIFF
--- a/src/Provider/Cognito.php
+++ b/src/Provider/Cognito.php
@@ -145,7 +145,7 @@ class Cognito extends AbstractProvider
      */
     public function getBaseAuthorizationUrl()
     {
-        return $this->getCognitoUrl('/authorize');
+        return $this->getCognitoUrl('/oauth2/authorize');
     }
 
     /**
@@ -154,7 +154,7 @@ class Cognito extends AbstractProvider
      */
     public function getBaseAccessTokenUrl(array $params)
     {
-        return $this->getCognitoUrl('/token');
+        return $this->getCognitoUrl('/oauth2/token');
     }
 
     /**


### PR DESCRIPTION
https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html

I see that repo is not maintained for a while. During the testing I figured out why it was not working and updated the URLs as per the documentation. 